### PR TITLE
Fix: add missing <mutex> header for C++ compiler compatibility

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <ostream>
 #include <thread>
-
+#include <mutex>
 #include "../include/prayer_timings.h"
 #include "../include/utils.h"
 #include "../include/waybar.h"

--- a/src/prayerTimings.cpp
+++ b/src/prayerTimings.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <thread>
-
+#include <mutex>
 #include "../include/prayer_timings.h"
 #include "../include/utils.h"
 #include "../include/waybar.h"


### PR DESCRIPTION
Fix build failure due to missing mutex header